### PR TITLE
[CSS] 모바일 "착 달라붙는" 레이아웃 지원

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,7 @@ function App() {
           //   '0 0 0 calc(50vw - 1px) auto', // 48em-62em
           //   '0 0 0 calc(50vw - 1px) auto', // 62em+
           // ]}
-          m={{
-            base: '0 auto', // 0-30em
-            md: '0 auto', // 30em-48em
-            lg: '0 0 0 calc(50vw - 1px)', // 48em-62em
-            xl: '0 0 0 calc(50vw - 1px)', // 62em+
-          }}
+          m={'0 auto'}
           // // ml="730.5px"
           // overflow="hidden"
           // // boxSizing="border-box"
@@ -38,13 +33,8 @@ function App() {
           minH="100vh"
           // w={['22.2rem', '24.2rem', '100vw', '100vw']}
           // w="20rem"
-          w={{
-            base: '24em', // 0-30em
-            md: '22rem', // 30em-48em
-            lg: '450px', // 48em-62em
-            xl: '450px', // 62em+
-          }}
-          minW="22rem"
+          w="100vw"
+          maxW="48rem"
           // m="0 auto"
           overflow="hidden"
           boxShadow="lg"

--- a/src/App.js
+++ b/src/App.js
@@ -11,31 +11,10 @@ function App() {
     <ChakraProvider theme={theme}>
       <Box boxSizing="border-box">
         <Box
-          // minH="100vh"
-          // w="35.2rem"
-          // minW="600px"
-          // // m="0 auto"
-          // maxW="422px"
-          // // minW="450px"
-          // m={['0 auto', '0 0 0 calc(50vw - 1px)']}
-          // m={[
-          //   '0 auto', // 0-30em
-          //   '0 auto', // 30em-48em
-          //   '0 0 0 calc(50vw - 1px) auto', // 48em-62em
-          //   '0 0 0 calc(50vw - 1px) auto', // 62em+
-          // ]}
-          m={'0 auto'}
-          // // ml="730.5px"
-          // overflow="hidden"
-          // // boxSizing="border-box"
-          // boxShadow="lg"
-          // rounded="md"
+          m={'0 auto'} // 어플리케이션 영역을 중앙에 위치시킴
           minH="100vh"
-          // w={['22.2rem', '24.2rem', '100vw', '100vw']}
-          // w="20rem"
-          w="100vw"
-          maxW="48rem"
-          // m="0 auto"
+          w="100vw" // 어플리케이션 영역 너비를 뷰포트 너비로 설정
+          maxW="48rem" // 어플리케이션 영역 너비가 48rem(768px)을 넘지 않도록 설정
           overflow="hidden"
           boxShadow="lg"
           rounded="md"


### PR DESCRIPTION
## 설명
- 모바일에서 착 달라붙도록 CSS 수정

## 작업내용
- 0e8d0586e08b1da019a8283f208fff16cf70746f
  - `width: 100vw` 로 설정하여 뷰포트 너비만큼 채우도록 하되, `max-width : 48rem (=768px)` 로 설정하여 뷰포트 너비가 768px 이상일때는 768px에 너비 고정되도록 했습니당
  - 앱 영역에 `margin: 0 auto` 설정하여 앱이 화면 중앙에 정렬되도록 했습니다.
- ece7e89e62c7c0ae94cdf98575357784e076c9ac
  - 불필요한 주석을 제거하고, 설정한 CSS 속성에 대한 설명 주석을 달았습니다. 